### PR TITLE
fix: use correct release tag for tarball upload

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -45,7 +45,7 @@ jobs:
           for tarball in packages/*/near-js-*.tgz; do
             if [ -f "$tarball" ]; then
               echo "Uploading $tarball"
-              gh release upload ${{ github.ref_name }} "$tarball"
+              gh release upload ${{ needs.release-please.outputs.tag_name }} "$tarball"
             fi
           done
         env:


### PR DESCRIPTION
## Summary
Fix the GitHub release upload to use the correct release tag instead of branch name.

## Problem
The previous workflow was using `${{ github.ref_name }}` which evaluates to `main` (the branch name), but it should use the actual release tag created by release-please.

## Solution
Changed to use `${{ needs.release-please.outputs.tag_name }}` which provides the correct release tag (e.g., `jsonrpc-types-v0.1.0`).

## Testing
After merging, this will fix the tarball upload for future releases. I'll also manually add tarballs to the current release for immediate availability.

🤖 Generated with [Claude Code](https://claude.ai/code)