### PR TITLE
docs: add GitHub release installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NEAR Protocol TypeScript RPC Client
 
-[![CI](https://github.com/your-org/near-rpc-typescript/actions/workflows/ci.yml/badge.svg)](https://github.com/your-org/near-rpc-typescript/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/your-org/near-rpc-typescript/branch/main/graph/badge.svg)](https://codecov.io/gh/your-org/near-rpc-typescript)
+[![CI](https://github.com/petersalomonsen/near-rpc-typescript/actions/workflows/ci.yml/badge.svg)](https://github.com/petersalomonsen/near-rpc-typescript/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/petersalomonsen/near-rpc-typescript/branch/main/graph/badge.svg)](https://codecov.io/gh/petersalomonsen/near-rpc-typescript)
 
 An automated, type-safe TypeScript client for NEAR Protocol's JSON-RPC API, generated from the official OpenAPI specification.
 
@@ -14,13 +14,27 @@ This monorepo contains two packages:
 
 ## 🚀 Quick Start
 
+### Installation
+
+Since these packages are distributed via GitHub releases, install them directly from the release tarballs:
+
 ```bash
-npm install @near-js/jsonrpc-client
-# or
-pnpm add @near-js/jsonrpc-client
-# or
-yarn add @near-js/jsonrpc-client
+npm install https://github.com/petersalomonsen/near-rpc-typescript/releases/download/jsonrpc-types-v0.1.0/near-js-jsonrpc-types-0.1.0.tgz
+npm install https://github.com/petersalomonsen/near-rpc-typescript/releases/download/jsonrpc-types-v0.1.0/near-js-jsonrpc-client-0.1.0.tgz
 ```
+
+Or add to your `package.json`:
+
+```json
+{
+  "dependencies": {
+    "@near-js/jsonrpc-types": "https://github.com/petersalomonsen/near-rpc-typescript/releases/download/jsonrpc-types-v0.1.0/near-js-jsonrpc-types-0.1.0.tgz",
+    "@near-js/jsonrpc-client": "https://github.com/petersalomonsen/near-rpc-typescript/releases/download/jsonrpc-types-v0.1.0/near-js-jsonrpc-client-0.1.0.tgz"
+  }
+}
+```
+
+> **Note**: Check the [releases page](https://github.com/petersalomonsen/near-rpc-typescript/releases) for the latest version and update the URLs accordingly.
 
 ```typescript
 import { NearRpcClient } from '@near-js/jsonrpc-client';


### PR DESCRIPTION
## Summary
Add clear installation instructions for consuming the packages from GitHub releases.

## Changes Made
### README Updates
- Added GitHub release installation instructions with npm commands
- Updated repository URLs from placeholder to actual GitHub repository  
- Added package.json dependency example
- Added note to check releases page for latest version

### GitHub Release
- Updated the current release (jsonrpc-types-v0.1.0) with installation instructions

## Installation Methods Added
**Direct npm install:**
```bash
npm install https://github.com/petersalomonsen/near-rpc-typescript/releases/download/jsonrpc-types-v0.1.0/near-js-jsonrpc-types-0.1.0.tgz
npm install https://github.com/petersalomonsen/near-rpc-typescript/releases/download/jsonrpc-types-v0.1.0/near-js-jsonrpc-client-0.1.0.tgz
```

**package.json dependencies:**
```json
{
  "dependencies": {
    "@near-js/jsonrpc-types": "https://github.com/petersalomonsen/near-rpc-typescript/releases/download/jsonrpc-types-v0.1.0/near-js-jsonrpc-types-0.1.0.tgz",
    "@near-js/jsonrpc-client": "https://github.com/petersalomonsen/near-rpc-typescript/releases/download/jsonrpc-types-v0.1.0/near-js-jsonrpc-client-0.1.0.tgz"
  }
}
```

## Benefits
- ✅ Clear installation instructions for users
- ✅ Multiple installation methods documented
- ✅ Updated repository references
- ✅ Guidance to check releases page for latest version

🤖 Generated with [Claude Code](https://claude.ai/code)