### PR TITLE
fix: resolve flaky performance test that fails on negative validation overhead

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,3 +22,8 @@ This file contains important notes and reminders for Claude when working on this
 - The `PATH_TO_METHOD_MAP` is now dynamically extracted from the OpenAPI spec
 - Run `pnpm generate` to regenerate types and schemas from the latest NEAR OpenAPI spec
 - The generator extracts method names from the `operationId` field in each path
+
+## Git Workflow
+
+- **Main branch is protected** - all changes must go through PRs, cannot push directly to main
+- Create feature branches and submit PRs for any fixes or changes

--- a/packages/jsonrpc-client/src/__tests__/performance.test.ts
+++ b/packages/jsonrpc-client/src/__tests__/performance.test.ts
@@ -283,7 +283,7 @@ describe('Zod Validation Performance Tests', () => {
       console.log('Validation overhead:', overhead, 'ms');
 
       expect(overhead).toBeLessThan(20); // Overhead should be under 20ms
-      expect(overhead).toBeGreaterThan(0); // There should be some overhead
+      expect(Math.abs(overhead)).toBeLessThan(10); // Overhead should be reasonable (accounting for measurement noise)
     });
 
     it('should verify validated and non-validated responses are identical', async () => {


### PR DESCRIPTION
## Problem
The CI build on main is failing due to a flaky performance test that expects validation overhead to always be positive. However, due to measurement noise, validation can sometimes appear slightly faster than no validation, resulting in negative overhead values.

**Failing assertion**: `expected -0.013074969999993247 to be greater than 0`

## Solution
- Changed the test to check that the absolute validation overhead is reasonable (`< 10ms`) instead of requiring it to be positive
- This accounts for measurement noise while still ensuring the overhead isn't unreasonably high
- The test now passes consistently regardless of minor measurement variations

## Additional Changes
- Updated `CLAUDE.md` to document that the main branch is protected and requires PRs

## Test Results
✅ All tests now pass locally with the fix
✅ Performance measurements are still validated, just more realistically

🤖 Generated with [Claude Code](https://claude.ai/code)