### PR TITLE
fix: update workflow to reflect all generated code, not just types

### DIFF
--- a/.github/workflows/update-types.yml
+++ b/.github/workflows/update-types.yml
@@ -1,4 +1,4 @@
-name: Update Generated Types
+name: Update Generated Code from OpenAPI
 
 on:
   schedule:
@@ -10,8 +10,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  update-types:
-    name: Update Types from OpenAPI Spec
+  update-generated-code:
+    name: Update Generated Code from OpenAPI Spec
     runs-on: ubuntu-latest
 
     steps:
@@ -34,11 +34,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Generate types
+      - name: Generate code from OpenAPI spec
         run: pnpm generate
 
       - name: Format generated code
-        run: pnpm prettier --write "packages/jsonrpc-types/src/**/*.ts"
+        run: pnpm format
 
       - name: Lint generated code
         run: pnpm lint
@@ -66,18 +66,22 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: 'feat: update generated types from OpenAPI spec'
+          commit-message: 'feat: update generated code from OpenAPI spec'
           committer: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
           author: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
-          title: 'feat: update generated types from OpenAPI spec'
+          title: 'feat: update generated code from OpenAPI spec'
           body: |
             This PR contains auto-generated updates from the NEAR Protocol OpenAPI specification.
 
             ## Changes
             - Updated TypeScript types
-            - Updated Zod schemas
+            - Updated Zod schemas  
+            - Updated RPC method mappings
+            - Updated client interfaces and functions
 
             ## Validation
+            - [x] Code generation completed successfully
+            - [x] Code formatted with prettier
             - [x] Types compile successfully
             - [x] Tests pass
             - [x] Linting passes
@@ -85,5 +89,5 @@ jobs:
             - [x] No breaking changes detected
 
             All validation steps are run automatically as part of this workflow.
-          branch: update-generated-types
+          branch: update-generated-code
           delete-branch: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,9 @@ This file contains important notes and reminders for Claude when working on this
 - Use `fix:` for bug fixes (triggers patch release)
 - Use `feat:` for new features (triggers minor release)
 - Use `chore:`, `docs:`, `test:`, `refactor:`, `perf:`, `style:` for non-releasing changes
+- **NEVER include "BREAKING CHANGE:" in commit messages unless there's an actual breaking change**
+  - Even "BREAKING CHANGE: None" will trigger a major version bump!
+  - Only use when making incompatible API changes
 - See RELEASE.md for full commit message conventions
 
 ## Testing


### PR DESCRIPTION
## Summary
- Fixed the update-types GitHub Actions workflow that was failing due to linting errors
- Updated workflow naming and descriptions to accurately reflect its broader scope
- Changed from formatting only `packages/jsonrpc-types/src/**/*.ts` to running `pnpm format` which formats all project files

## Problem
1. The workflow was failing because it only formatted TypeScript files in `packages/jsonrpc-types/src/` but the code generator also creates files in `packages/jsonrpc-client/src/`. The lint step checks all files, causing it to fail on the unformatted generated client files.

2. The workflow was named "Update Generated Types" but it actually generates much more than just types:
   - TypeScript types
   - Zod schemas  
   - RPC method mappings
   - Client interfaces and functions

## Solution
1. Use `pnpm format` instead of a partial prettier command to ensure all generated files are properly formatted before linting.

2. Renamed workflow, job, and step names to accurately reflect that it updates all generated code from the OpenAPI spec, not just types.

## Test plan
- [x] Verified `pnpm generate` runs successfully locally
- [x] Verified `pnpm format` formats all generated files
- [x] Verified `pnpm lint` passes after formatting
- [ ] GitHub Actions workflow should pass after this fix

🤖 Generated with [Claude Code](https://claude.ai/code)