### PR TITLE
fix: handle non-standard error responses in RPC results

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -84,6 +84,12 @@ jobs:
       - name: Run TypeScript validation-demo example
         run: pnpm tsx examples/typescript/validation-demo.ts
 
+      - name: Run TypeScript error-handling-demo example
+        run: pnpm tsx examples/typescript/error-handling-demo.ts
+
+      - name: Run TypeScript convenience-functions-error-handling example
+        run: pnpm tsx examples/typescript/convenience-functions-error-handling.ts
+
       # ESM JavaScript examples
       - name: Run ESM basic-usage example
         run: node examples/javascript-esm/basic-usage.js

--- a/examples/typescript/convenience-functions-error-handling.ts
+++ b/examples/typescript/convenience-functions-error-handling.ts
@@ -1,0 +1,74 @@
+/**
+ * Comprehensive Error Handling Example
+ * 
+ * This example demonstrates how all convenience functions in the NEAR RPC
+ * client properly handle error cases, such as non-existent accounts,
+ * methods, and access keys.
+ *
+ * To run this example:
+ * 1. Make sure you have pnpm installed (https://pnpm.io/installation).
+ * 2. Run `pnpm install` from the root of the repository.
+ * 3. Run `pnpm tsx examples/typescript/convenience-functions-error-handling.ts` from the root of the repository.
+ */
+
+import { NearRpcClient, viewAccount, viewFunction, viewAccessKey } from '@near-js/jsonrpc-client';
+
+console.log("=== NEAR RPC Convenience Functions Error Handling ===\n");
+
+const client = new NearRpcClient({ 
+  endpoint: "https://rpc.mainnet.fastnear.com"
+});
+
+// Example 1: viewAccount with non-existent account
+console.log("1. Attempting to view a non-existent account:");
+try {
+  await viewAccount(client, {
+    accountId: "this-account-definitely-does-not-exist-12345.near"
+  });
+  // If we reach here, the test failed - error was not thrown
+  console.error("   ❌ FAIL: Expected error was not thrown!");
+  process.exit(1);
+} catch(error: any) {
+  console.log("   ✓ Error correctly thrown:");
+  console.log(`     ${error.message}\n`);
+}
+
+// Example 2: viewFunction with non-existent method
+console.log("2. Attempting to call a non-existent contract method:");
+try {
+  await viewFunction(client, {
+    accountId: "webassemblymusic-treasury.sputnik-dao.near",        
+    methodName: "get_last_proposal_id_" // non-existent method
+  });
+  // If we reach here, the test failed - error was not thrown
+  console.error("   ❌ FAIL: Expected error was not thrown!");
+  process.exit(1);
+} catch(error: any) {
+  console.log("   ✓ Error correctly thrown:");
+  console.log(`     ${error.message}`);
+  if (error.data?.error) {
+    console.log(`     Details: ${error.data.error}\n`);
+  }
+}
+
+// Example 3: viewAccessKey with non-existent key
+console.log("3. Attempting to view a non-existent access key:");
+try {
+  await viewAccessKey(client, {
+    accountId: "near",
+    publicKey: "ed25519:11111111111111111111111111111111" // non-existent key
+  });
+  // If we reach here, the test failed - error was not thrown
+  console.error("   ❌ FAIL: Expected error was not thrown!");
+  process.exit(1);
+} catch(error: any) {
+  console.log("   ✓ Error correctly thrown:");
+  console.log(`     ${error.message}\n`);
+}
+
+console.log("=== All convenience functions handle errors properly! ===");
+
+// Bonus: Show a successful call for comparison
+console.log("\nFor comparison, here's a successful call:");
+const account = await viewAccount(client, { accountId: "near" });
+console.log(`✓ Account 'near' balance: ${account.amount} yoctoNEAR`);

--- a/examples/typescript/convenience-functions-error-handling.ts
+++ b/examples/typescript/convenience-functions-error-handling.ts
@@ -1,6 +1,6 @@
 /**
  * Comprehensive Error Handling Example
- * 
+ *
  * This example demonstrates how all convenience functions in the NEAR RPC
  * client properly handle error cases, such as non-existent accounts,
  * methods, and access keys.
@@ -11,40 +11,45 @@
  * 3. Run `pnpm tsx examples/typescript/convenience-functions-error-handling.ts` from the root of the repository.
  */
 
-import { NearRpcClient, viewAccount, viewFunction, viewAccessKey } from '@near-js/jsonrpc-client';
+import {
+  NearRpcClient,
+  viewAccount,
+  viewFunction,
+  viewAccessKey,
+} from '@near-js/jsonrpc-client';
 
-console.log("=== NEAR RPC Convenience Functions Error Handling ===\n");
+console.log('=== NEAR RPC Convenience Functions Error Handling ===\n');
 
-const client = new NearRpcClient({ 
-  endpoint: "https://rpc.mainnet.fastnear.com"
+const client = new NearRpcClient({
+  endpoint: 'https://rpc.mainnet.fastnear.com',
 });
 
 // Example 1: viewAccount with non-existent account
-console.log("1. Attempting to view a non-existent account:");
+console.log('1. Attempting to view a non-existent account:');
 try {
   await viewAccount(client, {
-    accountId: "this-account-definitely-does-not-exist-12345.near"
+    accountId: 'this-account-definitely-does-not-exist-12345.near',
   });
   // If we reach here, the test failed - error was not thrown
-  console.error("   ❌ FAIL: Expected error was not thrown!");
+  console.error('   ❌ FAIL: Expected error was not thrown!');
   process.exit(1);
-} catch(error: any) {
-  console.log("   ✓ Error correctly thrown:");
+} catch (error: any) {
+  console.log('   ✓ Error correctly thrown:');
   console.log(`     ${error.message}\n`);
 }
 
 // Example 2: viewFunction with non-existent method
-console.log("2. Attempting to call a non-existent contract method:");
+console.log('2. Attempting to call a non-existent contract method:');
 try {
   await viewFunction(client, {
-    accountId: "webassemblymusic-treasury.sputnik-dao.near",        
-    methodName: "get_last_proposal_id_" // non-existent method
+    accountId: 'webassemblymusic-treasury.sputnik-dao.near',
+    methodName: 'get_last_proposal_id_', // non-existent method
   });
   // If we reach here, the test failed - error was not thrown
-  console.error("   ❌ FAIL: Expected error was not thrown!");
+  console.error('   ❌ FAIL: Expected error was not thrown!');
   process.exit(1);
-} catch(error: any) {
-  console.log("   ✓ Error correctly thrown:");
+} catch (error: any) {
+  console.log('   ✓ Error correctly thrown:');
   console.log(`     ${error.message}`);
   if (error.data?.error) {
     console.log(`     Details: ${error.data.error}\n`);
@@ -52,23 +57,23 @@ try {
 }
 
 // Example 3: viewAccessKey with non-existent key
-console.log("3. Attempting to view a non-existent access key:");
+console.log('3. Attempting to view a non-existent access key:');
 try {
   await viewAccessKey(client, {
-    accountId: "near",
-    publicKey: "ed25519:11111111111111111111111111111111" // non-existent key
+    accountId: 'near',
+    publicKey: 'ed25519:11111111111111111111111111111111', // non-existent key
   });
   // If we reach here, the test failed - error was not thrown
-  console.error("   ❌ FAIL: Expected error was not thrown!");
+  console.error('   ❌ FAIL: Expected error was not thrown!');
   process.exit(1);
-} catch(error: any) {
-  console.log("   ✓ Error correctly thrown:");
+} catch (error: any) {
+  console.log('   ✓ Error correctly thrown:');
   console.log(`     ${error.message}\n`);
 }
 
-console.log("=== All convenience functions handle errors properly! ===");
+console.log('=== All convenience functions handle errors properly! ===');
 
 // Bonus: Show a successful call for comparison
 console.log("\nFor comparison, here's a successful call:");
-const account = await viewAccount(client, { accountId: "near" });
+const account = await viewAccount(client, { accountId: 'near' });
 console.log(`✓ Account 'near' balance: ${account.amount} yoctoNEAR`);

--- a/examples/typescript/error-handling-demo.ts
+++ b/examples/typescript/error-handling-demo.ts
@@ -1,6 +1,6 @@
 /**
  * Error Handling Example
- * 
+ *
  * This example demonstrates how the NEAR RPC client handles errors
  * when calling non-existent contract methods, both with and without
  * validation enabled.
@@ -11,28 +11,32 @@
  * 3. Run `pnpm tsx examples/typescript/error-handling-demo.ts` from the root of the repository.
  */
 
-import { NearRpcClient, viewFunction, enableValidation } from '@near-js/jsonrpc-client';
+import {
+  NearRpcClient,
+  viewFunction,
+  enableValidation,
+} from '@near-js/jsonrpc-client';
 
-console.log("=== NEAR RPC Error Handling Example ===\n");
+console.log('=== NEAR RPC Error Handling Example ===\n');
 
 // Example 1: Error handling without validation
-console.log("1. Calling non-existent method WITHOUT validation:");
-console.log("   (Errors are now properly thrown)\n");
+console.log('1. Calling non-existent method WITHOUT validation:');
+console.log('   (Errors are now properly thrown)\n');
 
-const clientWithoutValidation = new NearRpcClient({ 
-  endpoint: "https://rpc.mainnet.fastnear.com"
+const clientWithoutValidation = new NearRpcClient({
+  endpoint: 'https://rpc.mainnet.fastnear.com',
 });
 
 try {
   await viewFunction(clientWithoutValidation, {
-    accountId: "webassemblymusic-treasury.sputnik-dao.near",        
-    methodName: "get_last_proposal_id_" // non-existent method
+    accountId: 'webassemblymusic-treasury.sputnik-dao.near',
+    methodName: 'get_last_proposal_id_', // non-existent method
   });
   // If we reach here, the test failed - error was not thrown
-  console.error("❌ FAIL: Expected error was not thrown!");
+  console.error('❌ FAIL: Expected error was not thrown!');
   process.exit(1);
-} catch(error: any) {
-  console.log("✓ Error correctly thrown:");
+} catch (error: any) {
+  console.log('✓ Error correctly thrown:');
   console.log(`  Type: ${error.name}`);
   console.log(`  Message: ${error.message}`);
   if (error.data) {
@@ -41,27 +45,27 @@ try {
   }
 }
 
-console.log("\n" + "=".repeat(50) + "\n");
+console.log('\n' + '='.repeat(50) + '\n');
 
 // Example 2: Error handling with validation enabled
-console.log("2. Calling non-existent method WITH validation:");
-console.log("   (Server errors are now properly displayed)\n");
+console.log('2. Calling non-existent method WITH validation:');
+console.log('   (Server errors are now properly displayed)\n');
 
-const clientWithValidation = new NearRpcClient({ 
-  endpoint: "https://rpc.mainnet.fastnear.com", 
-  validation: enableValidation() 
+const clientWithValidation = new NearRpcClient({
+  endpoint: 'https://rpc.mainnet.fastnear.com',
+  validation: enableValidation(),
 });
 
 try {
   await viewFunction(clientWithValidation, {
-    accountId: "webassemblymusic-treasury.sputnik-dao.near",        
-    methodName: "get_last_proposal_id_" // non-existent method
+    accountId: 'webassemblymusic-treasury.sputnik-dao.near',
+    methodName: 'get_last_proposal_id_', // non-existent method
   });
   // If we reach here, the test failed - error was not thrown
-  console.error("❌ FAIL: Expected error was not thrown!");
+  console.error('❌ FAIL: Expected error was not thrown!');
   process.exit(1);
-} catch(error: any) {
-  console.log("✓ Error correctly thrown with clear message:");
+} catch (error: any) {
+  console.log('✓ Error correctly thrown with clear message:');
   console.log(`  Type: ${error.name}`);
   console.log(`  Message: ${error.message}`);
   if (error.data) {
@@ -69,4 +73,4 @@ try {
   }
 }
 
-console.log("\n=== Error handling working correctly in both cases! ===");
+console.log('\n=== Error handling working correctly in both cases! ===');

--- a/examples/typescript/error-handling-demo.ts
+++ b/examples/typescript/error-handling-demo.ts
@@ -1,0 +1,72 @@
+/**
+ * Error Handling Example
+ * 
+ * This example demonstrates how the NEAR RPC client handles errors
+ * when calling non-existent contract methods, both with and without
+ * validation enabled.
+ *
+ * To run this example:
+ * 1. Make sure you have pnpm installed (https://pnpm.io/installation).
+ * 2. Run `pnpm install` from the root of the repository.
+ * 3. Run `pnpm tsx examples/typescript/error-handling-demo.ts` from the root of the repository.
+ */
+
+import { NearRpcClient, viewFunction, enableValidation } from '@near-js/jsonrpc-client';
+
+console.log("=== NEAR RPC Error Handling Example ===\n");
+
+// Example 1: Error handling without validation
+console.log("1. Calling non-existent method WITHOUT validation:");
+console.log("   (Errors are now properly thrown)\n");
+
+const clientWithoutValidation = new NearRpcClient({ 
+  endpoint: "https://rpc.mainnet.fastnear.com"
+});
+
+try {
+  await viewFunction(clientWithoutValidation, {
+    accountId: "webassemblymusic-treasury.sputnik-dao.near",        
+    methodName: "get_last_proposal_id_" // non-existent method
+  });
+  // If we reach here, the test failed - error was not thrown
+  console.error("❌ FAIL: Expected error was not thrown!");
+  process.exit(1);
+} catch(error: any) {
+  console.log("✓ Error correctly thrown:");
+  console.log(`  Type: ${error.name}`);
+  console.log(`  Message: ${error.message}`);
+  if (error.data) {
+    console.log(`  Block Height: ${error.data.blockHeight}`);
+    console.log(`  Original Error: ${error.data.error}`);
+  }
+}
+
+console.log("\n" + "=".repeat(50) + "\n");
+
+// Example 2: Error handling with validation enabled
+console.log("2. Calling non-existent method WITH validation:");
+console.log("   (Server errors are now properly displayed)\n");
+
+const clientWithValidation = new NearRpcClient({ 
+  endpoint: "https://rpc.mainnet.fastnear.com", 
+  validation: enableValidation() 
+});
+
+try {
+  await viewFunction(clientWithValidation, {
+    accountId: "webassemblymusic-treasury.sputnik-dao.near",        
+    methodName: "get_last_proposal_id_" // non-existent method
+  });
+  // If we reach here, the test failed - error was not thrown
+  console.error("❌ FAIL: Expected error was not thrown!");
+  process.exit(1);
+} catch(error: any) {
+  console.log("✓ Error correctly thrown with clear message:");
+  console.log(`  Type: ${error.name}`);
+  console.log(`  Message: ${error.message}`);
+  if (error.data) {
+    console.log(`  Block Height: ${error.data.blockHeight}`);
+  }
+}
+
+console.log("\n=== Error handling working correctly in both cases! ===");

--- a/packages/jsonrpc-client/src/__tests__/error-handling.test.ts
+++ b/packages/jsonrpc-client/src/__tests__/error-handling.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NearRpcClient, JsonRpcClientError } from '../client.js';
+import { viewFunction, viewAccount, viewAccessKey } from '../convenience.js';
+import { enableValidation } from '../validation.js';
+
+// Mock fetch for testing
+const mockFetch = vi.fn();
+global.fetch = mockFetch as any;
+
+describe('Error Handling', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  describe('viewFunction error handling', () => {
+    it('should throw error when RPC returns error in result (without validation)', async () => {
+      const client = new NearRpcClient('https://rpc.test.near.org');
+
+      // Mock RPC error response
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          jsonrpc: '2.0',
+          id: 'dontcare',
+          result: {
+            block_hash: 'test-hash',
+            block_height: 123456,
+            error:
+              'wasm execution failed with error: MethodResolveError(MethodNotFound)',
+            logs: [],
+          },
+        }),
+      });
+
+      await expect(
+        viewFunction(client, {
+          accountId: 'test.near',
+          methodName: 'non_existent_method',
+        })
+      ).rejects.toThrow(JsonRpcClientError);
+
+      // Need to mock again as the previous call consumed the mock
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          jsonrpc: '2.0',
+          id: 'dontcare',
+          result: {
+            block_hash: 'test-hash',
+            block_height: 123456,
+            error:
+              'wasm execution failed with error: MethodResolveError(MethodNotFound)',
+            logs: [],
+          },
+        }),
+      });
+
+      await expect(
+        viewFunction(client, {
+          accountId: 'test.near',
+          methodName: 'non_existent_method',
+        })
+      ).rejects.toThrow(
+        'RPC Error: wasm execution failed with error: MethodResolveError(MethodNotFound)'
+      );
+    });
+
+    it('should throw error with server message when validation is enabled', async () => {
+      const client = new NearRpcClient({
+        endpoint: 'https://rpc.test.near.org',
+        validation: enableValidation(),
+      });
+
+      // Mock RPC error response
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          jsonrpc: '2.0',
+          id: 'dontcare',
+          result: {
+            block_hash: 'test-hash',
+            block_height: 123456,
+            error:
+              'wasm execution failed with error: MethodResolveError(MethodNotFound)',
+            logs: [],
+          },
+        }),
+      });
+
+      await expect(
+        viewFunction(client, {
+          accountId: 'test.near',
+          methodName: 'non_existent_method',
+        })
+      ).rejects.toThrow(
+        'RPC Error: wasm execution failed with error: MethodResolveError(MethodNotFound)'
+      );
+    });
+  });
+
+  describe('viewAccount error handling', () => {
+    it('should throw error when account does not exist', async () => {
+      const client = new NearRpcClient('https://rpc.test.near.org');
+
+      // Mock RPC error response for non-existent account
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          jsonrpc: '2.0',
+          id: 'dontcare',
+          result: {
+            error: 'Server error',
+            block_hash: 'test-hash',
+            block_height: 123456,
+          },
+        }),
+      });
+
+      await expect(
+        viewAccount(client, {
+          accountId: 'non-existent-account.near',
+        })
+      ).rejects.toThrow('RPC Error: Server error');
+    });
+  });
+
+  describe('viewAccessKey error handling', () => {
+    it('should throw error when access key does not exist', async () => {
+      const client = new NearRpcClient('https://rpc.test.near.org');
+
+      // Mock RPC error response for non-existent access key
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          jsonrpc: '2.0',
+          id: 'dontcare',
+          result: {
+            error: 'access key ed25519:ABC123 does not exist while viewing',
+            block_hash: 'test-hash',
+            block_height: 123456,
+          },
+        }),
+      });
+
+      await expect(
+        viewAccessKey(client, {
+          accountId: 'test.near',
+          publicKey: 'ed25519:ABC123',
+        })
+      ).rejects.toThrow(
+        'RPC Error: access key ed25519:ABC123 does not exist while viewing'
+      );
+    });
+  });
+
+  describe('standard JSON-RPC error handling', () => {
+    it('should handle standard JSON-RPC errors', async () => {
+      const client = new NearRpcClient('https://rpc.test.near.org');
+
+      // Mock standard JSON-RPC error response
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          jsonrpc: '2.0',
+          id: 'dontcare',
+          error: {
+            code: -32601,
+            message: 'Method not found',
+            data: null,
+          },
+        }),
+      });
+
+      await expect(
+        viewFunction(client, {
+          accountId: 'test.near',
+          methodName: 'test_method',
+        })
+      ).rejects.toThrow('Method not found');
+    });
+  });
+});

--- a/packages/jsonrpc-client/src/client.ts
+++ b/packages/jsonrpc-client/src/client.ts
@@ -232,6 +232,21 @@ export class NearRpcClient {
           ? convertKeysToCamelCase(jsonResponse.result)
           : jsonResponse.result;
 
+        // Check if the result contains an error field (non-standard NEAR RPC error response)
+        // This happens when validation is disabled and certain RPC errors occur
+        if (
+          camelCaseResult &&
+          typeof camelCaseResult === 'object' &&
+          'error' in camelCaseResult
+        ) {
+          const errorMessage = (camelCaseResult as any).error;
+          throw new JsonRpcClientError(
+            `RPC Error: ${errorMessage}`,
+            -32000, // Generic RPC error code
+            camelCaseResult
+          );
+        }
+
         // Validate method-specific response structure after camelCase conversion
         if (this.validation && 'validateMethodResponse' in this.validation) {
           // Create a camelCase version of the response for validation


### PR DESCRIPTION
## Summary
- Fixed error handling inconsistencies in viewFunction and other convenience methods
- Errors are now properly thrown instead of returned when validation is disabled
- Server errors are properly displayed when validation is enabled

## Problem

When using the `@near-js/jsonrpc-client` library, there were two issues with error handling:

1. **Validation errors obscured actual server errors**: When validation was enabled and a non-existent method was called, the library threw verbose validation errors without the actual server error message.

2. **Errors not thrown when validation disabled**: When validation was disabled and an error occurred, the function returned the error in the response object instead of throwing it.

## Solution

1. **Added error detection in `makeRequest`**: The client now checks if the result contains an `error` field (non-standard NEAR RPC error response) and throws a proper `JsonRpcClientError`.

2. **Improved validation error handling**: The validation now checks for error fields before validating schemas, ensuring server errors are properly reported even with validation enabled.

## Test plan
- [x] Added comprehensive error handling tests in `error-handling.test.ts`
- [x] Verified all convenience functions handle errors correctly
- [x] All existing tests pass
- [x] Manual testing shows proper error messages in both scenarios

Fixes #48

🤖 Generated with [Claude Code](https://claude.ai/code)